### PR TITLE
fix abi struct layout bugs and bind missing db.h functions

### DIFF
--- a/src/TidesDB/ColumnFamily.cs
+++ b/src/TidesDB/ColumnFamily.cs
@@ -273,6 +273,13 @@ public sealed class ColumnFamily
                 TombstoneRatio = nativeStats.TombstoneRatio,
                 MaxSstDensity = nativeStats.MaxSstDensity,
                 MaxSstDensityLevel = nativeStats.MaxSstDensityLevel,
+                WalBytesWritten = nativeStats.WalBytesWritten,
+                FlushBytesWritten = nativeStats.FlushBytesWritten,
+                CompactionBytesWritten = nativeStats.CompactionBytesWritten,
+                CompactionBytesRead = nativeStats.CompactionBytesRead,
+                UserBytesWritten = nativeStats.UserBytesWritten,
+                FlushCount = nativeStats.FlushCount,
+                CompactionCount = nativeStats.CompactionCount,
                 Config = ReadColumnFamilyConfig(nativeStats.Config),
             };
 
@@ -332,47 +339,10 @@ public sealed class ColumnFamily
         }
     }
 
-    private static unsafe ColumnFamilyConfig? ReadColumnFamilyConfig(nint configPtr)
+    private static ColumnFamilyConfig? ReadColumnFamilyConfig(nint configPtr)
     {
         if (configPtr == nint.Zero) return null;
-
         var n = Marshal.PtrToStructure<NativeColumnFamilyConfig>(configPtr);
-
-        string comparatorName = "";
-        var nameBytes = new byte[64];
-        Marshal.Copy(configPtr + (int)Marshal.OffsetOf<NativeColumnFamilyConfig>(nameof(NativeColumnFamilyConfig.ComparatorName)),
-            nameBytes, 0, nameBytes.Length);
-        int nameLen = Array.IndexOf<byte>(nameBytes, 0);
-        if (nameLen < 0) nameLen = nameBytes.Length;
-        if (nameLen > 0) comparatorName = System.Text.Encoding.UTF8.GetString(nameBytes, 0, nameLen);
-
-        return new ColumnFamilyConfig
-        {
-            WriteBufferSize = (ulong)n.WriteBufferSize,
-            LevelSizeRatio = (ulong)n.LevelSizeRatio,
-            MinLevels = n.MinLevels,
-            DividingLevelOffset = n.DividingLevelOffset,
-            KlogValueThreshold = (ulong)n.KlogValueThreshold,
-            CompressionAlgorithm = (CompressionAlgorithm)n.CompressionAlgo,
-            EnableBloomFilter = n.EnableBloomFilter != 0,
-            BloomFpr = n.BloomFpr,
-            EnableBlockIndexes = n.EnableBlockIndexes != 0,
-            IndexSampleRatio = n.IndexSampleRatio,
-            BlockIndexPrefixLen = n.BlockIndexPrefixLen,
-            SyncMode = (SyncMode)n.SyncMode,
-            SyncIntervalUs = n.SyncIntervalUs,
-            ComparatorName = comparatorName,
-            SkipListMaxLevel = n.SkipListMaxLevel,
-            SkipListProbability = n.SkipListProbability,
-            DefaultIsolationLevel = (IsolationLevel)n.DefaultIsolationLevel,
-            MinDiskSpace = n.MinDiskSpace,
-            L1FileCountTrigger = n.L1FileCountTrigger,
-            L0QueueStallThreshold = n.L0QueueStallThreshold,
-            TombstoneDensityTrigger = n.TombstoneDensityTrigger,
-            TombstoneDensityMinEntries = n.TombstoneDensityMinEntries,
-            UseBtree = n.UseBtree != 0,
-            ObjectLazyCompaction = n.ObjectLazyCompaction != 0,
-            ObjectPrefetchCompaction = n.ObjectPrefetchCompaction != 0,
-        };
+        return ColumnFamilyConfig.FromNative(n);
     }
 }

--- a/src/TidesDB/Comparator.cs
+++ b/src/TidesDB/Comparator.cs
@@ -1,0 +1,127 @@
+// Copyright (C) TidesDB
+//
+// Original Author: Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace TidesDB;
+
+/// <summary>
+/// A custom key comparator. Returns a negative value if <paramref name="key1"/> sorts before
+/// <paramref name="key2"/>, zero if they are equal, and a positive value if it sorts after.
+/// </summary>
+/// <remarks>
+/// The callback is invoked from native code on the hot path of every memtable and compaction
+/// comparison, potentially concurrently on background threads. It must be deterministic, total,
+/// thread-safe, and must not throw (an exception is caught and treated as "equal"). Keep it fast.
+/// The keys are valid only for the duration of the call - do not retain the spans.
+/// </remarks>
+/// <param name="key1">The first key.</param>
+/// <param name="key2">The second key.</param>
+/// <returns>Negative, zero, or positive per the ordering of <paramref name="key1"/> vs <paramref name="key2"/>.</returns>
+public delegate int ComparatorFunction(ReadOnlySpan<byte> key1, ReadOnlySpan<byte> key2);
+
+/// <summary>
+/// The built-in comparators TidesDB ships with. Each is registered automatically on database open
+/// under its conventional name (so a column family can reference it via
+/// <see cref="ColumnFamilyConfig.ComparatorName"/>); this enum lets you also register one under a
+/// custom name via <see cref="TidesDb.RegisterBuiltInComparator"/>.
+/// </summary>
+public enum BuiltInComparator
+{
+    /// <summary>Binary, byte-by-byte comparison (the default, registered as "memcmp").</summary>
+    Memcmp,
+
+    /// <summary>Null-terminated string comparison (registered as "lexicographic").</summary>
+    Lexicographic,
+
+    /// <summary>Unsigned 64-bit integer comparison (registered as "uint64").</summary>
+    Uint64,
+
+    /// <summary>Signed 64-bit integer comparison (registered as "int64").</summary>
+    Int64,
+
+    /// <summary>Reverse binary comparison (registered as "reverse").</summary>
+    ReverseMemcmp,
+
+    /// <summary>Case-insensitive ASCII comparison (registered as "case_insensitive").</summary>
+    CaseInsensitive
+}
+
+[UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+internal delegate int NativeComparatorFn(nint key1, nuint key1Size, nint key2, nuint key2Size, nint ctx);
+
+/// <summary>
+/// Internal plumbing for comparator registration: the managed-to-native bridge and built-in
+/// function-pointer resolution.
+/// </summary>
+internal static class ComparatorBridge
+{
+    internal static readonly NativeComparatorFn Bridge = Invoke;
+    internal static readonly nint BridgePtr = Marshal.GetFunctionPointerForDelegate(Bridge);
+
+    private static unsafe int Invoke(nint key1, nuint key1Size, nint key2, nuint key2Size, nint ctx)
+    {
+        try
+        {
+            var handle = GCHandle.FromIntPtr(ctx);
+            var comparator = (ComparatorFunction)handle.Target!;
+            var span1 = new ReadOnlySpan<byte>((void*)key1, (int)key1Size);
+            var span2 = new ReadOnlySpan<byte>((void*)key2, (int)key2Size);
+            return comparator(span1, span2);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private static readonly object s_libLock = new();
+    private static nint s_libHandle;
+
+    /// <summary>
+    /// Resolves the raw native function pointer for a built-in comparator export so it can be
+    /// registered under a custom name with native-speed comparison (no managed callback).
+    /// </summary>
+    internal static nint GetBuiltInPointer(BuiltInComparator comparator)
+    {
+        var entryPoint = comparator switch
+        {
+            BuiltInComparator.Memcmp => "tidesdb_comparator_memcmp",
+            BuiltInComparator.Lexicographic => "tidesdb_comparator_lexicographic",
+            BuiltInComparator.Uint64 => "tidesdb_comparator_uint64",
+            BuiltInComparator.Int64 => "tidesdb_comparator_int64",
+            BuiltInComparator.ReverseMemcmp => "tidesdb_comparator_reverse_memcmp",
+            BuiltInComparator.CaseInsensitive => "tidesdb_comparator_case_insensitive",
+            _ => throw new ArgumentOutOfRangeException(nameof(comparator))
+        };
+
+        if (s_libHandle == nint.Zero)
+        {
+            lock (s_libLock)
+            {
+                if (s_libHandle == nint.Zero)
+                {
+                    var assembly = typeof(ComparatorBridge).Assembly;
+                    // Routes through the registered DllImportResolver (NativeLibraryResolver).
+                    s_libHandle = NativeLibrary.Load("libtidesdb", assembly, null);
+                }
+            }
+        }
+
+        return NativeLibrary.GetExport(s_libHandle, entryPoint);
+    }
+}

--- a/src/TidesDB/Config.cs
+++ b/src/TidesDB/Config.cs
@@ -114,6 +114,13 @@ public sealed class Config
     public int MaxConcurrentFlushes { get; init; } = s_defaultMaxConcurrentFlushes;
 
     /// <summary>
+    /// Close behavior. False (default) cancels in-flight compactions at their next checkpoint for
+    /// a fast shutdown - the merge discards its uncommitted output and leaves inputs intact, so no
+    /// data is lost. True lets in-flight compactions run to completion before close returns.
+    /// </summary>
+    public bool FinishCompactionsOnClose { get; init; } = false;
+
+    /// <summary>
     /// Creates a default configuration with the specified database path. Field defaults
     /// are sourced from the C library (tidesdb_default_config) so the binding tracks
     /// library defaults rather than duplicating constants.
@@ -263,9 +270,49 @@ public sealed class ColumnFamilyConfig
     /// </summary>
     public static ColumnFamilyConfig Default => FromNativeDefaults();
 
-    private static unsafe ColumnFamilyConfig FromNativeDefaults()
+    private static ColumnFamilyConfig FromNativeDefaults()
+        => FromNative(NativeMethods.tidesdb_default_column_family_config());
+
+    /// <summary>
+    /// Loads a column family configuration from an INI file section. Unspecified keys retain the
+    /// library defaults. Mirrors the native <c>tidesdb_cf_config_load_from_ini</c>.
+    /// </summary>
+    /// <param name="iniFile">Path to the INI file.</param>
+    /// <param name="sectionName">Section name within the INI file.</param>
+    /// <returns>The loaded configuration.</returns>
+    public static ColumnFamilyConfig LoadFromIni(string iniFile, string sectionName)
     {
         var n = NativeMethods.tidesdb_default_column_family_config();
+        var result = NativeMethods.tidesdb_cf_config_load_from_ini(iniFile, sectionName, ref n);
+        TidesDBException.ThrowIfError(result, "failed to load column family config from INI");
+        return FromNative(n);
+    }
+
+    /// <summary>
+    /// Saves this column family configuration to an INI file section, creating or updating the file.
+    /// Mirrors the native <c>tidesdb_cf_config_save_to_ini</c>.
+    /// </summary>
+    /// <param name="iniFile">Path to the INI file.</param>
+    /// <param name="sectionName">Section name within the INI file.</param>
+    public void SaveToIni(string iniFile, string sectionName)
+    {
+        var n = TidesDb.CreateNativeColumnFamilyConfigPublic(this);
+        var result = NativeMethods.tidesdb_cf_config_save_to_ini(iniFile, sectionName, ref n);
+        TidesDBException.ThrowIfError(result, "failed to save column family config to INI");
+    }
+
+    internal static unsafe ColumnFamilyConfig FromNative(NativeColumnFamilyConfig n)
+    {
+        string comparatorName = "";
+        int nameLen = 0;
+        while (nameLen < 64 && n.ComparatorName[nameLen] != 0) nameLen++;
+        if (nameLen > 0)
+        {
+            var nameBytes = new byte[nameLen];
+            for (int i = 0; i < nameLen; i++) nameBytes[i] = n.ComparatorName[i];
+            comparatorName = System.Text.Encoding.UTF8.GetString(nameBytes);
+        }
+
         return new ColumnFamilyConfig
         {
             WriteBufferSize = (ulong)n.WriteBufferSize,
@@ -281,6 +328,7 @@ public sealed class ColumnFamilyConfig
             BlockIndexPrefixLen = n.BlockIndexPrefixLen,
             SyncMode = (SyncMode)n.SyncMode,
             SyncIntervalUs = n.SyncIntervalUs,
+            ComparatorName = comparatorName,
             SkipListMaxLevel = n.SkipListMaxLevel,
             SkipListProbability = n.SkipListProbability,
             DefaultIsolationLevel = (IsolationLevel)n.DefaultIsolationLevel,
@@ -352,6 +400,38 @@ public sealed class ObjectStoreConfig
     /// Use path-style URLs for S3 (default: false for AWS, set true for MinIO).
     /// </summary>
     public bool S3UsePathStyle { get; init; } = false;
+
+    /// <summary>
+    /// Custom CA bundle file path for the S3 TLS connection (null = system bundle).
+    /// Setting this routes connector creation through the full S3 config (TLS-capable) factory.
+    /// </summary>
+    public string? S3TlsCaPath { get; init; }
+
+    /// <summary>
+    /// Disables S3 TLS peer and host verification (test only, insecure; default: false).
+    /// Setting this routes connector creation through the full S3 config (TLS-capable) factory.
+    /// </summary>
+    public bool S3TlsInsecureSkipVerify { get; init; } = false;
+
+    /// <summary>
+    /// S3 connector multipart upload threshold in bytes (0 = library default). When non-zero,
+    /// routes connector creation through the full S3 config factory.
+    /// </summary>
+    public ulong S3MultipartThreshold { get; init; } = 0;
+
+    /// <summary>
+    /// S3 connector multipart chunk size in bytes (0 = library default). When non-zero, routes
+    /// connector creation through the full S3 config factory.
+    /// </summary>
+    public ulong S3MultipartPartSize { get; init; } = 0;
+
+    /// <summary>
+    /// True when any S3 option requires the full S3 config factory
+    /// (<c>tidesdb_objstore_s3_create_config</c>) rather than the positional factory.
+    /// </summary>
+    internal bool RequiresS3ConfigFactory =>
+        S3TlsCaPath != null || S3TlsInsecureSkipVerify ||
+        S3MultipartThreshold != 0 || S3MultipartPartSize != 0;
 
     /// <summary>
     /// Local directory for cached SSTable files (null = use db_path).

--- a/src/TidesDB/Enums.cs
+++ b/src/TidesDB/Enums.cs
@@ -81,5 +81,6 @@ public enum ErrorCode
     InvalidDb = -10,
     Unknown = -11,
     Locked = -12,
-    Readonly = -13
+    Readonly = -13,
+    Busy = -14
 }

--- a/src/TidesDB/Library.cs
+++ b/src/TidesDB/Library.cs
@@ -1,0 +1,76 @@
+// Copyright (C) TidesDB
+//
+// Original Author: Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using TidesDB.Native;
+
+namespace TidesDB;
+
+/// <summary>
+/// Process-wide TidesDB library lifecycle and capability helpers.
+/// </summary>
+public static class Library
+{
+    /// <summary>
+    /// Initializes the TidesDB library with the default system allocator.
+    /// Calling this is optional - <see cref="TidesDb.Open"/> lazily initializes the library on
+    /// first use. Call it explicitly only if you need initialization to happen up front (for
+    /// example before raising the open-file limit). Safe to call once; a second call without an
+    /// intervening <see cref="Shutdown"/> is a no-op.
+    /// </summary>
+    /// <returns>True if the library was initialized by this call, false if it was already initialized.</returns>
+    public static bool Initialize()
+    {
+        // tidesdb_init returns 0 on success, -1 if already initialized.
+        var result = NativeMethods.tidesdb_init(nint.Zero, nint.Zero, nint.Zero, nint.Zero);
+        return result == 0;
+    }
+
+    /// <summary>
+    /// Finalizes the TidesDB library and resets the allocator. Call after all databases are closed.
+    /// After this returns, <see cref="Initialize"/> may be called again.
+    /// </summary>
+    public static void Shutdown()
+    {
+        NativeMethods.tidesdb_finalize();
+    }
+
+    /// <summary>
+    /// Raises this process's open-file ceiling toward <paramref name="desired"/> descriptors so a
+    /// database can keep more SSTables open. Must be called BEFORE <see cref="TidesDb.Open"/> - the
+    /// engine sizes <c>MaxOpenSstables</c> to fit the ceiling at open time. This is an explicit,
+    /// opt-in operator action; TidesDB never raises the limit on its own. A failed or partial raise
+    /// is non-fatal.
+    /// </summary>
+    /// <param name="desired">Target descriptor count; values &lt;= 0 just report the current ceiling.</param>
+    /// <returns>The open-file ceiling in effect after the attempt.</returns>
+    public static long RaiseOpenFileLimit(long desired)
+    {
+        return NativeMethods.tidesdb_raise_open_file_limit(desired);
+    }
+
+    /// <summary>
+    /// Reports whether a compression backend is compiled into the loaded native library.
+    /// <see cref="CompressionAlgorithm.None"/> is always available; the rest depend on the
+    /// build-time <c>-DTIDESDB_WITH_*</c> options. Lets callers reject an unsupported algorithm up
+    /// front instead of failing at compress/flush time.
+    /// </summary>
+    /// <param name="algorithm">The compression algorithm to query.</param>
+    /// <returns>True if the algorithm can be used in this build.</returns>
+    public static bool IsCompressionAvailable(CompressionAlgorithm algorithm)
+    {
+        return NativeMethods.tidesdb_compression_available((int)algorithm) == 1;
+    }
+}

--- a/src/TidesDB/Native/NativeMethods.cs
+++ b/src/TidesDB/Native/NativeMethods.cs
@@ -22,6 +22,21 @@ internal static partial class NativeMethods
 {
     private const string LibraryName = "libtidesdb";
 
+    // Initialization / finalization
+    [LibraryImport(LibraryName, EntryPoint = "tidesdb_init")]
+    internal static partial int tidesdb_init(nint mallocFn, nint callocFn, nint reallocFn, nint freeFn);
+
+    [LibraryImport(LibraryName, EntryPoint = "tidesdb_finalize")]
+    internal static partial void tidesdb_finalize();
+
+    // Raise the process open-file ceiling (call before tidesdb_open)
+    [LibraryImport(LibraryName, EntryPoint = "tidesdb_raise_open_file_limit")]
+    internal static partial long tidesdb_raise_open_file_limit(long desired);
+
+    // Query whether a compression backend is compiled into this build
+    [LibraryImport(LibraryName, EntryPoint = "tidesdb_compression_available")]
+    internal static partial int tidesdb_compression_available(int type);
+
     // Database operations
     [LibraryImport(LibraryName, EntryPoint = "tidesdb_open")]
     internal static partial int tidesdb_open(ref NativeConfig config, out nint db);
@@ -177,6 +192,17 @@ internal static partial class NativeMethods
     [LibraryImport(LibraryName, EntryPoint = "tidesdb_register_comparator", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial int tidesdb_register_comparator(nint db, string name, nint fn, string? ctxStr, nint ctx);
 
+    // INI config persistence
+    [LibraryImport(LibraryName, EntryPoint = "tidesdb_cf_config_load_from_ini", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int tidesdb_cf_config_load_from_ini(string iniFile, string sectionName, ref NativeColumnFamilyConfig config);
+
+    [LibraryImport(LibraryName, EntryPoint = "tidesdb_cf_config_save_to_ini", StringMarshalling = StringMarshalling.Utf8)]
+    internal static partial int tidesdb_cf_config_save_to_ini(string iniFile, string sectionName, ref NativeColumnFamilyConfig config);
+
+    // Cancel background compaction db-wide (fast-shutdown helper)
+    [LibraryImport(LibraryName, EntryPoint = "tidesdb_cancel_background_work")]
+    internal static partial int tidesdb_cancel_background_work(nint db);
+
     // Commit hook operations
     [LibraryImport(LibraryName, EntryPoint = "tidesdb_cf_set_commit_hook")]
     internal static partial int tidesdb_cf_set_commit_hook(nint cf, nint fn, nint ctx);
@@ -219,6 +245,10 @@ internal static partial class NativeMethods
     // Object store operations
     [LibraryImport(LibraryName, EntryPoint = "tidesdb_objstore_s3_create", StringMarshalling = StringMarshalling.Utf8)]
     internal static partial nint tidesdb_objstore_s3_create(string endpoint, string bucket, string? prefix, string accessKey, string secretKey, string? region, int useSsl, int usePathStyle);
+
+    // S3 connector from full config struct (TLS + multipart tuning)
+    [LibraryImport(LibraryName, EntryPoint = "tidesdb_objstore_s3_create_config")]
+    internal static partial nint tidesdb_objstore_s3_create_config(ref NativeObjStoreS3Config config);
 
     [LibraryImport(LibraryName, EntryPoint = "tidesdb_objstore_default_config")]
     internal static partial NativeObjStoreConfig tidesdb_objstore_default_config();

--- a/src/TidesDB/Native/NativeStructs.cs
+++ b/src/TidesDB/Native/NativeStructs.cs
@@ -39,6 +39,7 @@ internal struct NativeConfig
     public nint ObjectStore;
     public nint ObjectStoreConfig;
     public int MaxConcurrentFlushes;
+    public int FinishCompactionsOnClose;
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -60,6 +61,23 @@ internal struct NativeObjStoreConfig
     public int ReplicaMode;
     public ulong ReplicaSyncIntervalUs;
     public int ReplicaReplayWal;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+internal struct NativeObjStoreS3Config
+{
+    public nint Endpoint;
+    public nint Bucket;
+    public nint Prefix;
+    public nint AccessKey;
+    public nint SecretKey;
+    public nint Region;
+    public int UseSsl;
+    public int UsePathStyle;
+    public nint TlsCaPath;
+    public int TlsInsecureSkipVerify;
+    public nuint MultipartThreshold;
+    public nuint MultipartPartSize;
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -135,6 +153,14 @@ internal struct NativeStats
     public nint LevelTombstoneCounts;
     public double MaxSstDensity;
     public int MaxSstDensityLevel;
+    // write-amplification counters (lifetime since open, on-disk framed bytes)
+    public ulong WalBytesWritten;
+    public ulong FlushBytesWritten;
+    public ulong CompactionBytesWritten;
+    public ulong CompactionBytesRead;
+    public ulong UserBytesWritten;
+    public ulong FlushCount;
+    public ulong CompactionCount;
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -183,4 +209,13 @@ internal struct NativeDbStats
     public ulong TotalUploads;
     public ulong TotalUploadFailures;
     public int ReplicaMode;
+    // write-amplification counters (lifetime since open, on-disk framed bytes)
+    public ulong UwalBytesWritten;
+    public ulong WalBytesWritten;
+    public ulong FlushBytesWritten;
+    public ulong CompactionBytesWritten;
+    public ulong CompactionBytesRead;
+    public ulong UserBytesWritten;
+    public ulong FlushCount;
+    public ulong CompactionCount;
 }

--- a/src/TidesDB/Stats.cs
+++ b/src/TidesDB/Stats.cs
@@ -125,6 +125,42 @@ public sealed record Stats
     /// 1-based level index where <see cref="MaxSstDensity"/> was observed (0 if none).
     /// </summary>
     public int MaxSstDensityLevel { get; init; }
+
+    /// <summary>
+    /// Framed bytes appended to this column family's WAL (0 in unified memtable mode).
+    /// Lifetime since open. Divide write totals by <see cref="UserBytesWritten"/> for write amplification.
+    /// </summary>
+    public ulong WalBytesWritten { get; init; }
+
+    /// <summary>
+    /// On-disk bytes this column family's flushes wrote to L0 SSTables (lifetime since open).
+    /// </summary>
+    public ulong FlushBytesWritten { get; init; }
+
+    /// <summary>
+    /// On-disk bytes this column family's compactions wrote (lifetime since open).
+    /// </summary>
+    public ulong CompactionBytesWritten { get; init; }
+
+    /// <summary>
+    /// On-disk bytes this column family's compactions read as input (lifetime since open).
+    /// </summary>
+    public ulong CompactionBytesRead { get; init; }
+
+    /// <summary>
+    /// Logical key+value bytes committed to this column family (write-amplification denominator).
+    /// </summary>
+    public ulong UserBytesWritten { get; init; }
+
+    /// <summary>
+    /// Number of flushed SSTables produced by this column family (lifetime since open).
+    /// </summary>
+    public ulong FlushCount { get; init; }
+
+    /// <summary>
+    /// Number of compaction output SSTables produced by this column family (lifetime since open).
+    /// </summary>
+    public ulong CompactionCount { get; init; }
 }
 
 /// <summary>
@@ -286,6 +322,48 @@ public sealed class DbStats
     /// Whether running in read-only replica mode.
     /// </summary>
     public bool ReplicaMode { get; init; }
+
+    /// <summary>
+    /// Framed bytes appended to the shared unified WAL (0 if unified memtable mode is off).
+    /// Lifetime since open.
+    /// </summary>
+    public ulong UwalBytesWritten { get; init; }
+
+    /// <summary>
+    /// Per-CF WAL bytes summed across all column families (lifetime since open).
+    /// </summary>
+    public ulong WalBytesWritten { get; init; }
+
+    /// <summary>
+    /// Flush output bytes summed across all column families (lifetime since open).
+    /// </summary>
+    public ulong FlushBytesWritten { get; init; }
+
+    /// <summary>
+    /// Compaction output bytes summed across all column families (lifetime since open).
+    /// </summary>
+    public ulong CompactionBytesWritten { get; init; }
+
+    /// <summary>
+    /// Compaction input bytes summed across all column families (lifetime since open).
+    /// </summary>
+    public ulong CompactionBytesRead { get; init; }
+
+    /// <summary>
+    /// Logical committed bytes summed across all column families (write-amplification denominator).
+    /// Db-wide write amplification = (Uwal + Wal + Flush + Compaction bytes written) / UserBytesWritten.
+    /// </summary>
+    public ulong UserBytesWritten { get; init; }
+
+    /// <summary>
+    /// Flushed SSTables summed across all column families (lifetime since open).
+    /// </summary>
+    public ulong FlushCount { get; init; }
+
+    /// <summary>
+    /// Compaction output SSTables summed across all column families (lifetime since open).
+    /// </summary>
+    public ulong CompactionCount { get; init; }
 }
 
 /// <summary>

--- a/src/TidesDB/TidesDB.cs
+++ b/src/TidesDB/TidesDB.cs
@@ -31,6 +31,7 @@ public sealed class TidesDb : IDisposable
     private nint _objStorePtr;
     private nint _objStoreConfigPtr;
     private nint _localCachePathPtr;
+    private readonly List<GCHandle> _comparatorHandles = new();
 
     private TidesDb(nint handle, nint dbPathPtr, nint objStorePtr, nint objStoreConfigPtr, nint localCachePathPtr)
     {
@@ -62,16 +63,7 @@ public sealed class TidesDb : IDisposable
                     ObjectStoreConnectorType.Filesystem =>
                         NativeMethods.tidesdb_objstore_fs_create(
                             osCfg.FsRootDir ?? throw new ArgumentException("FsRootDir is required for filesystem connector")),
-                    ObjectStoreConnectorType.S3 =>
-                        NativeMethods.tidesdb_objstore_s3_create(
-                            osCfg.S3Endpoint ?? throw new ArgumentException("S3Endpoint is required for S3 connector"), 
-                            osCfg.S3Bucket ?? throw new ArgumentException("S3Bucket is required for S3 connector"), 
-                            osCfg.S3KeyPrefix, 
-                            osCfg.S3AccessKey ?? throw new ArgumentException("S3AccessKey is required for S3 connector"), 
-                            osCfg.S3SecretKey ?? throw new ArgumentException("S3SecretKey is required for S3 connector"), 
-                            osCfg.S3Region, 
-                            osCfg.S3UseSsl ? 1 : 0, 
-                            osCfg.S3UsePathStyle ? 1 : 0),
+                    ObjectStoreConnectorType.S3 => CreateS3Connector(osCfg),
                     _ => throw new ArgumentException($"Unknown connector type: {osCfg.ConnectorType}")
                 };
 
@@ -125,7 +117,8 @@ public sealed class TidesDb : IDisposable
                 UnifiedMemtableSyncIntervalUs = config.UnifiedMemtableSyncIntervalUs,
                 ObjectStore = objStorePtr,
                 ObjectStoreConfig = objStoreConfigPtr,
-                MaxConcurrentFlushes = config.MaxConcurrentFlushes
+                MaxConcurrentFlushes = config.MaxConcurrentFlushes,
+                FinishCompactionsOnClose = config.FinishCompactionsOnClose ? 1 : 0
             };
 
             var result = NativeMethods.tidesdb_open(ref nativeConfig, out var dbHandle);
@@ -292,15 +285,51 @@ public sealed class TidesDb : IDisposable
     }
 
     /// <summary>
-    /// Registers a custom comparator with the database.
+    /// Registers a custom comparator implemented as a managed callback under the given name.
+    /// Register comparators before creating any column family that references the name; a column
+    /// family's comparator cannot be changed after creation. The callback runs on the comparison
+    /// hot path (see <see cref="ComparatorFunction"/> for the threading and performance contract);
+    /// for native-speed ordering of standard key shapes prefer
+    /// <see cref="RegisterBuiltInComparator"/>. The delegate is kept alive for the lifetime of this
+    /// database instance.
     /// </summary>
-    /// <param name="name">The comparator name.</param>
-    /// <param name="ctxStr">Optional context string.</param>
-    public void RegisterComparator(string name, string? ctxStr = null)
+    /// <param name="name">The comparator name (must be unique, under 64 bytes).</param>
+    /// <param name="comparator">The comparison callback.</param>
+    /// <param name="ctxStr">Optional context string passed through to the native registry.</param>
+    public void RegisterComparator(string name, ComparatorFunction comparator, string? ctxStr = null)
     {
         ThrowIfDisposed();
-        var result = NativeMethods.tidesdb_register_comparator(_handle, name, nint.Zero, ctxStr, nint.Zero);
-        TidesDBException.ThrowIfError(result, "failed to register comparator");
+        ArgumentNullException.ThrowIfNull(comparator);
+
+        var gcHandle = GCHandle.Alloc(comparator);
+        var result = NativeMethods.tidesdb_register_comparator(
+            _handle, name, ComparatorBridge.BridgePtr, ctxStr, GCHandle.ToIntPtr(gcHandle));
+
+        if (result != 0)
+        {
+            gcHandle.Free();
+            TidesDBException.ThrowIfError(result, "failed to register comparator");
+        }
+
+        _comparatorHandles.Add(gcHandle);
+    }
+
+    /// <summary>
+    /// Registers one of the built-in native comparators under a custom name. Unlike a managed
+    /// <see cref="RegisterComparator(string, ComparatorFunction, string?)"/> callback, this incurs
+    /// no managed transition on the comparison hot path. Each built-in is already registered under
+    /// its conventional name (for example <see cref="BuiltInComparator.Memcmp"/> as "memcmp"); use
+    /// this only when you want an additional alias.
+    /// </summary>
+    /// <param name="name">The comparator name (must be unique, under 64 bytes).</param>
+    /// <param name="comparator">The built-in comparator to register.</param>
+    /// <param name="ctxStr">Optional context string passed through to the native registry.</param>
+    public void RegisterBuiltInComparator(string name, BuiltInComparator comparator, string? ctxStr = null)
+    {
+        ThrowIfDisposed();
+        var fnPtr = ComparatorBridge.GetBuiltInPointer(comparator);
+        var result = NativeMethods.tidesdb_register_comparator(_handle, name, fnPtr, ctxStr, nint.Zero);
+        TidesDBException.ThrowIfError(result, "failed to register built-in comparator");
     }
 
     /// <summary>
@@ -336,6 +365,19 @@ public sealed class TidesDb : IDisposable
         ThrowIfDisposed();
         var result = NativeMethods.tidesdb_purge(_handle);
         TidesDBException.ThrowIfError(result, "failed to purge database");
+    }
+
+    /// <summary>
+    /// Cancels background compaction db-wide: in-flight merges bail safely and queued compaction is
+    /// skipped. Flushes are unaffected, so durability is preserved. Blocks (bounded) until compaction
+    /// is idle. The effect is sticky for the session and reset on the next open - intended to be
+    /// called right before <see cref="Dispose"/> for a fast shutdown.
+    /// </summary>
+    public void CancelBackgroundWork()
+    {
+        ThrowIfDisposed();
+        var result = NativeMethods.tidesdb_cancel_background_work(_handle);
+        TidesDBException.ThrowIfError(result, "failed to cancel background work");
     }
 
     /// <summary>
@@ -382,7 +424,15 @@ public sealed class TidesDb : IDisposable
             UploadQueueDepth = (ulong)nativeStats.UploadQueueDepth,
             TotalUploads = nativeStats.TotalUploads,
             TotalUploadFailures = nativeStats.TotalUploadFailures,
-            ReplicaMode = nativeStats.ReplicaMode != 0
+            ReplicaMode = nativeStats.ReplicaMode != 0,
+            UwalBytesWritten = nativeStats.UwalBytesWritten,
+            WalBytesWritten = nativeStats.WalBytesWritten,
+            FlushBytesWritten = nativeStats.FlushBytesWritten,
+            CompactionBytesWritten = nativeStats.CompactionBytesWritten,
+            CompactionBytesRead = nativeStats.CompactionBytesRead,
+            UserBytesWritten = nativeStats.UserBytesWritten,
+            FlushCount = nativeStats.FlushCount,
+            CompactionCount = nativeStats.CompactionCount
         };
     }
 
@@ -407,6 +457,61 @@ public sealed class TidesDb : IDisposable
             HitRate = nativeStats.HitRate,
             NumPartitions = (ulong)nativeStats.NumPartitions
         };
+    }
+
+    private static nint CreateS3Connector(ObjectStoreConfig osCfg)
+    {
+        var endpoint = osCfg.S3Endpoint ?? throw new ArgumentException("S3Endpoint is required for S3 connector");
+        var bucket = osCfg.S3Bucket ?? throw new ArgumentException("S3Bucket is required for S3 connector");
+        var accessKey = osCfg.S3AccessKey ?? throw new ArgumentException("S3AccessKey is required for S3 connector");
+        var secretKey = osCfg.S3SecretKey ?? throw new ArgumentException("S3SecretKey is required for S3 connector");
+
+        if (!osCfg.RequiresS3ConfigFactory)
+        {
+            return NativeMethods.tidesdb_objstore_s3_create(
+                endpoint, bucket, osCfg.S3KeyPrefix, accessKey, secretKey,
+                osCfg.S3Region, osCfg.S3UseSsl ? 1 : 0, osCfg.S3UsePathStyle ? 1 : 0);
+        }
+
+        // Advanced TLS / multipart options require the full-config factory. Native copies the
+        // fields, so the marshalled strings need only outlive the call.
+        var endpointPtr = Marshal.StringToHGlobalAnsi(endpoint);
+        var bucketPtr = Marshal.StringToHGlobalAnsi(bucket);
+        var prefixPtr = osCfg.S3KeyPrefix != null ? Marshal.StringToHGlobalAnsi(osCfg.S3KeyPrefix) : nint.Zero;
+        var accessKeyPtr = Marshal.StringToHGlobalAnsi(accessKey);
+        var secretKeyPtr = Marshal.StringToHGlobalAnsi(secretKey);
+        var regionPtr = osCfg.S3Region != null ? Marshal.StringToHGlobalAnsi(osCfg.S3Region) : nint.Zero;
+        var caPathPtr = osCfg.S3TlsCaPath != null ? Marshal.StringToHGlobalAnsi(osCfg.S3TlsCaPath) : nint.Zero;
+
+        try
+        {
+            var nativeS3 = new NativeObjStoreS3Config
+            {
+                Endpoint = endpointPtr,
+                Bucket = bucketPtr,
+                Prefix = prefixPtr,
+                AccessKey = accessKeyPtr,
+                SecretKey = secretKeyPtr,
+                Region = regionPtr,
+                UseSsl = osCfg.S3UseSsl ? 1 : 0,
+                UsePathStyle = osCfg.S3UsePathStyle ? 1 : 0,
+                TlsCaPath = caPathPtr,
+                TlsInsecureSkipVerify = osCfg.S3TlsInsecureSkipVerify ? 1 : 0,
+                MultipartThreshold = (nuint)osCfg.S3MultipartThreshold,
+                MultipartPartSize = (nuint)osCfg.S3MultipartPartSize
+            };
+            return NativeMethods.tidesdb_objstore_s3_create_config(ref nativeS3);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(endpointPtr);
+            Marshal.FreeHGlobal(bucketPtr);
+            if (prefixPtr != nint.Zero) Marshal.FreeHGlobal(prefixPtr);
+            Marshal.FreeHGlobal(accessKeyPtr);
+            Marshal.FreeHGlobal(secretKeyPtr);
+            if (regionPtr != nint.Zero) Marshal.FreeHGlobal(regionPtr);
+            if (caPathPtr != nint.Zero) Marshal.FreeHGlobal(caPathPtr);
+        }
     }
 
     internal static unsafe NativeColumnFamilyConfig CreateNativeColumnFamilyConfigPublic(ColumnFamilyConfig config)
@@ -494,5 +599,11 @@ public sealed class TidesDb : IDisposable
             Marshal.FreeHGlobal(_objStoreConfigPtr);
             _objStoreConfigPtr = nint.Zero;
         }
+
+        foreach (var handle in _comparatorHandles)
+        {
+            if (handle.IsAllocated) handle.Free();
+        }
+        _comparatorHandles.Clear();
     }
 }

--- a/src/TidesDB/TidesDB.csproj
+++ b/src/TidesDB/TidesDB.csproj
@@ -9,7 +9,7 @@
 
     <!-- Package metadata -->
     <PackageId>TidesDB</PackageId>
-    <Version>0.6.1</Version>
+    <Version>0.6.2</Version>
     <Authors>TidesDB</Authors>
     <Company>TidesDB</Company>
     <Description>Official C# bindings for TidesDB, a high-performance embedded key-value storage engine. Wraps the native libtidesdb shared library, which must be installed on the target system.</Description>

--- a/src/TidesDB/TidesDBException.cs
+++ b/src/TidesDB/TidesDBException.cs
@@ -54,6 +54,7 @@ public class TidesDBException : Exception
             ErrorCode.InvalidDb => "invalid database handle",
             ErrorCode.Locked => "database is locked",
             ErrorCode.Readonly => "database is read-only",
+            ErrorCode.Busy => "resource busy",
             _ => "unknown error"
         };
 

--- a/tests/TidesDB.Tests/FfiCoverageTests.cs
+++ b/tests/TidesDB.Tests/FfiCoverageTests.cs
@@ -1,0 +1,332 @@
+// Copyright (C) TidesDB
+//
+// Original Author: Alex Gaetano Padula
+//
+// Licensed under the Mozilla Public License, v. 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.mozilla.org/en-US/MPL/2.0/
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Text;
+using Xunit;
+
+namespace TidesDB.Tests;
+
+/// <summary>
+/// Tests for FFI surface added to track db.h: write-amplification stats, ErrorCode.Busy,
+/// init/finalize, open-file limit, compression availability, background-work cancellation,
+/// INI config round-trip, finish-compactions-on-close, and comparator registration.
+/// </summary>
+public class FfiCoverageTests : IDisposable
+{
+    private readonly string _testDbPath;
+    private TidesDb? _db;
+
+    public FfiCoverageTests()
+    {
+        _testDbPath = Path.Combine(Path.GetTempPath(), $"tidesdb_new_{Guid.NewGuid()}");
+    }
+
+    public void Dispose()
+    {
+        _db?.Dispose();
+        if (Directory.Exists(_testDbPath))
+        {
+            Directory.Delete(_testDbPath, true);
+        }
+    }
+
+    private TidesDb OpenDatabase()
+    {
+        _db = TidesDb.Open(new Config { DbPath = _testDbPath });
+        return _db;
+    }
+
+    // ---- Library-level helpers -------------------------------------------------
+
+    [Fact]
+    public void Library_RaiseOpenFileLimit_ReportsCeiling()
+    {
+        // Querying with <= 0 just reports the current ceiling without changing it.
+        var ceiling = Library.RaiseOpenFileLimit(0);
+        Assert.True(ceiling > 0);
+    }
+
+    [Fact]
+    public void Library_IsCompressionAvailable_NoneAlwaysTrue()
+    {
+        Assert.True(Library.IsCompressionAvailable(CompressionAlgorithm.None));
+    }
+
+    [Fact]
+    public void Library_IsCompressionAvailable_Lz4_MatchesUsableAlgorithm()
+    {
+        // Whatever the build reports as available must actually be usable for a CF.
+        if (Library.IsCompressionAvailable(CompressionAlgorithm.Lz4))
+        {
+            using var db = OpenDatabase();
+            db.CreateColumnFamily("lz4_cf", new ColumnFamilyConfig
+            {
+                CompressionAlgorithm = CompressionAlgorithm.Lz4
+            });
+            Assert.NotNull(db.GetColumnFamily("lz4_cf"));
+        }
+    }
+
+    [Fact]
+    public void Library_Initialize_IsIdempotentAfterOpen()
+    {
+        // Opening a database lazily initializes the library, so a subsequent explicit
+        // Initialize() is a no-op and must report "already initialized" rather than throw.
+        using var db = OpenDatabase();
+        Assert.False(Library.Initialize());
+    }
+
+    // ---- ErrorCode.Busy --------------------------------------------------------
+
+    [Fact]
+    public void ErrorCode_Busy_HasExpectedValue()
+    {
+        Assert.Equal(-14, (int)ErrorCode.Busy);
+        var ex = new TidesDBException(ErrorCode.Busy, "ctx");
+        Assert.Equal(ErrorCode.Busy, ex.ErrorCode);
+        Assert.Contains("busy", ex.Message);
+    }
+
+    // ---- finish_compactions_on_close ABI field ---------------------------------
+
+    [Fact]
+    public void Config_FinishCompactionsOnClose_OpensAndCloses()
+    {
+        var db = TidesDb.Open(new Config
+        {
+            DbPath = _testDbPath,
+            FinishCompactionsOnClose = true
+        });
+        db.CreateColumnFamily("cf");
+        var cf = db.GetColumnFamily("cf")!;
+        using (var txn = db.BeginTransaction())
+        {
+            txn.Put(cf, "k"u8.ToArray(), "v"u8.ToArray());
+            txn.Commit();
+        }
+        // The struct layout fix means close reads a valid flag (no OOB read / corruption).
+        db.Dispose();
+    }
+
+    // ---- CancelBackgroundWork --------------------------------------------------
+
+    [Fact]
+    public void CancelBackgroundWork_ShouldSucceed()
+    {
+        using var db = OpenDatabase();
+        db.CreateColumnFamily("cf");
+        var cf = db.GetColumnFamily("cf")!;
+        using (var txn = db.BeginTransaction())
+        {
+            txn.Put(cf, "k"u8.ToArray(), "v"u8.ToArray());
+            txn.Commit();
+        }
+        db.CancelBackgroundWork();
+    }
+
+    // ---- Write-amplification stats (struct tail fields) ------------------------
+
+    [Fact]
+    public void GetStats_WriteAmpFields_ArePopulatedAfterFlush()
+    {
+        using var db = OpenDatabase();
+        db.CreateColumnFamily("wa_cf", new ColumnFamilyConfig { WriteBufferSize = 64 * 1024 });
+        var cf = db.GetColumnFamily("wa_cf")!;
+
+        using (var txn = db.BeginTransaction())
+        {
+            for (int i = 0; i < 500; i++)
+            {
+                txn.Put(cf, Encoding.UTF8.GetBytes($"key{i:D5}"), Encoding.UTF8.GetBytes($"value{i}"));
+            }
+            txn.Commit();
+        }
+        cf.FlushMemtable();
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (cf.IsFlushing() && DateTime.UtcNow < deadline) Thread.Sleep(50);
+
+        var stats = cf.GetStats();
+        // user_bytes_written counts logical committed key+value bytes; must be non-zero.
+        Assert.True(stats.UserBytesWritten > 0, "expected UserBytesWritten > 0 after commits");
+        Assert.True(stats.WalBytesWritten > 0, "expected WalBytesWritten > 0 in per-CF (non-unified) mode");
+    }
+
+    [Fact]
+    public void GetDbStats_WriteAmpFields_AreReadable()
+    {
+        using var db = OpenDatabase();
+        db.CreateColumnFamily("cf");
+        var cf = db.GetColumnFamily("cf")!;
+        using (var txn = db.BeginTransaction())
+        {
+            txn.Put(cf, "k"u8.ToArray(), "v"u8.ToArray());
+            txn.Commit();
+        }
+
+        var stats = db.GetDbStats();
+        // Reading these tail fields proves the NativeDbStats layout matches the C struct
+        // (a short struct would have corrupted the stack on the native write).
+        Assert.True(stats.UserBytesWritten > 0);
+        Assert.True(stats.UwalBytesWritten == 0, "unified WAL volume is 0 when unified mode is off");
+    }
+
+    // ---- INI config round-trip -------------------------------------------------
+
+    [Fact]
+    public void CfConfig_SaveAndLoadIni_RoundTrips()
+    {
+        var iniFile = Path.Combine(Path.GetTempPath(), $"tidesdb_cfg_{Guid.NewGuid()}.ini");
+        try
+        {
+            var original = new ColumnFamilyConfig
+            {
+                WriteBufferSize = 32 * 1024 * 1024,
+                CompressionAlgorithm = CompressionAlgorithm.Zstd,
+                BloomFpr = 0.005,
+                MinLevels = 7,
+                UseBtree = true
+            };
+
+            original.SaveToIni(iniFile, "mycf");
+            Assert.True(File.Exists(iniFile));
+
+            var loaded = ColumnFamilyConfig.LoadFromIni(iniFile, "mycf");
+            Assert.Equal(original.WriteBufferSize, loaded.WriteBufferSize);
+            Assert.Equal(original.CompressionAlgorithm, loaded.CompressionAlgorithm);
+            Assert.Equal(original.BloomFpr, loaded.BloomFpr);
+            Assert.Equal(original.MinLevels, loaded.MinLevels);
+            Assert.Equal(original.UseBtree, loaded.UseBtree);
+        }
+        finally
+        {
+            if (File.Exists(iniFile)) File.Delete(iniFile);
+        }
+    }
+
+    [Fact]
+    public void CfConfig_LoadFromIni_UsableForCreate()
+    {
+        var iniFile = Path.Combine(Path.GetTempPath(), $"tidesdb_cfg_{Guid.NewGuid()}.ini");
+        try
+        {
+            new ColumnFamilyConfig { CompressionAlgorithm = CompressionAlgorithm.Lz4 }
+                .SaveToIni(iniFile, "section1");
+            var loaded = ColumnFamilyConfig.LoadFromIni(iniFile, "section1");
+
+            using var db = OpenDatabase();
+            db.CreateColumnFamily("from_ini", loaded);
+            Assert.NotNull(db.GetColumnFamily("from_ini"));
+        }
+        finally
+        {
+            if (File.Exists(iniFile)) File.Delete(iniFile);
+        }
+    }
+
+    // ---- Comparator registration ----------------------------------------------
+
+    [Fact]
+    public void RegisterBuiltInComparator_UnderCustomName_ShouldRegister()
+    {
+        using var db = OpenDatabase();
+        db.RegisterBuiltInComparator("my_uint64", BuiltInComparator.Uint64);
+        Assert.True(db.GetComparator("my_uint64"));
+    }
+
+    [Fact]
+    public void RegisterBuiltInComparator_DrivesCorrectOrdering()
+    {
+        using var db = OpenDatabase();
+        db.RegisterBuiltInComparator("reverse_alias", BuiltInComparator.ReverseMemcmp);
+        db.CreateColumnFamily("rev_cf", new ColumnFamilyConfig { ComparatorName = "reverse_alias" });
+        var cf = db.GetColumnFamily("rev_cf")!;
+
+        using (var txn = db.BeginTransaction())
+        {
+            txn.Put(cf, "a"u8.ToArray(), "1"u8.ToArray());
+            txn.Put(cf, "b"u8.ToArray(), "2"u8.ToArray());
+            txn.Put(cf, "c"u8.ToArray(), "3"u8.ToArray());
+            txn.Commit();
+        }
+
+        using var readTxn = db.BeginTransaction();
+        using var iter = readTxn.NewIterator(cf);
+        iter.SeekToFirst();
+        Assert.True(iter.Valid());
+        // Reverse comparator => "c" sorts first.
+        Assert.Equal("c", Encoding.UTF8.GetString(iter.Key()));
+    }
+
+    [Fact]
+    public void RegisterComparator_ManagedDelegate_ShouldRegisterAndOrder()
+    {
+        using var db = OpenDatabase();
+        int callCount = 0;
+
+        // Order purely by key length, then by bytes (a total order).
+        db.RegisterComparator("by_length", (k1, k2) =>
+        {
+            Interlocked.Increment(ref callCount);
+            if (k1.Length != k2.Length) return k1.Length - k2.Length;
+            return k1.SequenceCompareTo(k2);
+        });
+
+        Assert.True(db.GetComparator("by_length"));
+
+        db.CreateColumnFamily("len_cf", new ColumnFamilyConfig { ComparatorName = "by_length" });
+        var cf = db.GetColumnFamily("len_cf")!;
+
+        using (var txn = db.BeginTransaction())
+        {
+            txn.Put(cf, "ccc"u8.ToArray(), "3"u8.ToArray());
+            txn.Put(cf, "a"u8.ToArray(), "1"u8.ToArray());
+            txn.Put(cf, "bb"u8.ToArray(), "2"u8.ToArray());
+            txn.Commit();
+        }
+
+        using var readTxn = db.BeginTransaction();
+        using var iter = readTxn.NewIterator(cf);
+        iter.SeekToFirst();
+
+        var order = new List<string>();
+        while (iter.Valid())
+        {
+            order.Add(Encoding.UTF8.GetString(iter.Key()));
+            iter.Next();
+        }
+
+        Assert.Equal(new[] { "a", "bb", "ccc" }, order);
+        Assert.True(callCount > 0, "managed comparator delegate should have been invoked");
+    }
+
+    [Fact]
+    public void RegisterComparator_NullDelegate_ShouldThrow()
+    {
+        using var db = OpenDatabase();
+        Assert.Throws<ArgumentNullException>(() => db.RegisterComparator("bad", null!));
+    }
+
+    [Fact]
+    public void RegisterComparator_DuplicateName_ShouldThrow()
+    {
+        using var db = OpenDatabase();
+        // "memcmp" is auto-registered on open; re-registering must fail with InvalidArgs.
+        var ex = Assert.Throws<TidesDBException>(() =>
+            db.RegisterBuiltInComparator("memcmp", BuiltInComparator.Memcmp));
+        Assert.Equal(ErrorCode.InvalidArgs, ex.ErrorCode);
+    }
+}

--- a/tests/TidesDB.Tests/TidesDBTests.cs
+++ b/tests/TidesDB.Tests/TidesDBTests.cs
@@ -1746,7 +1746,9 @@ public class TidesDBTests : IDisposable
     public void MaxConcurrentFlushes_ShouldRespectConfig()
     {
         var defaults = Config.Default(_testDbPath);
-        Assert.True(defaults.MaxConcurrentFlushes > 0,
+        // The library default is 0 (a sentinel meaning "pin to the resolved flush-thread count"),
+        // so the binding must surface that value verbatim rather than substitute a constant.
+        Assert.True(defaults.MaxConcurrentFlushes >= 0,
             "Config.Default should source MaxConcurrentFlushes from tidesdb_default_config");
 
         var config = new Config


### PR DESCRIPTION
the native config dbstats and stats structs were missing trailing fields causing out of bounds reads and writes and stack corruption when opening a database and reading database stats. added the finish compactions on close field to config the eight write amplification counters to dbstats and the seven write amplification counters to stats and exposed them all on the managed types

fixed register comparator which always failed because it passed a null function pointer. you can now register a custom managed comparator delegate or alias one of the six built in comparators under a new name

bound the remaining db.h surface that was missing init and finalize raise open file limit compression available cancel background work cf config load and save to ini and the s3 create config factory with tls and multipart options. added the busy error code

added sixteen tests covering the new surface fixed a stale max concurrent flushes assertion extended the csharp reference docs and bumped the package version to zero six two